### PR TITLE
Complete Bracket Node Interface With Getter For Indices

### DIFF
--- a/nesting/src/main/java/brackets/nesting/BracketNode.java
+++ b/nesting/src/main/java/brackets/nesting/BracketNode.java
@@ -3,6 +3,7 @@ package brackets.nesting;
 import java.util.ArrayList;
 import java.util.Objects;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** A Node representing a Pair of Brackets.
@@ -80,6 +81,12 @@ public final class BracketNode
             }
         }
         return true;
+    }
+
+    @Nonnull
+    @Override
+    public int[] getIndices() {
+        return new int[]{open, close};
     }
 
     @Override

--- a/nesting/src/main/java/brackets/nesting/BracketNodeInterface.java
+++ b/nesting/src/main/java/brackets/nesting/BracketNodeInterface.java
@@ -1,11 +1,18 @@
 package brackets.nesting;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** A Bracket Node Tree Interface.
  * Each Node has an array of Sub-Nodes, which are randomly accessible.
  */
 public interface BracketNodeInterface {
+
+	/** Obtain the open and close bracket indices of this node.
+	 * @return An Array containing the two index values.
+	 */
+	@Nonnull
+	int[] getIndices();
 
 	/** Determine the number of direct internal nodes.
 	 * @return The count of nodes directly inside this node.

--- a/nesting/src/test/java/brackets/nesting/BracketNodeTest.java
+++ b/nesting/src/test/java/brackets/nesting/BracketNodeTest.java
@@ -56,6 +56,31 @@ public final class BracketNodeTest {
 	}
 
 	@Test
+	public void testGetIndices() {
+		final var indices = mInstance.getIndices();
+		assertEquals(
+			open, indices[0]
+		);
+		assertEquals(
+			close, indices[1]
+		);
+	}
+
+	@Test
+	public void testGetIndices_AlternateValues() {
+		open = 300;
+		close = 50001;
+		mInstance = new BracketNode(open, close);
+		final var indices = mInstance.getIndices();
+		assertEquals(
+			open, indices[0]
+		);
+		assertEquals(
+			close, indices[1]
+		);
+	}
+
+	@Test
 	public void testCountSubNodes_Empty_ReturnsZero() {
 		assertEquals(
 			0, mInstance.countSubNodes()


### PR DESCRIPTION
### Add To Bracket Node Interface
`BracketNodeInterface` is incomplete without a method providing the bracket indices.

### Get Indices Returns Integer Array
The goal of this return type is to allow implementations and interface users to have more freedom.

For example, there can be an implementation that uses an array internally, and gives out the same array to users. That's good if the goal is to minimize allocations!

A more interesting example, in my opinion, is the use of the smallest data type necessary internally. It can help reduce the minimum persistent memory requirement of the Bracket Node Tree. This is the main reason for introducing the `BracketNodeInterface`.

### Compatibility Note
`BracketNode` provides public field access to the open and close indices. These will not be removed.